### PR TITLE
1.29.0 patch

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Spyglass",
-    "version_number": "2.1.0",
+    "version_number": "2.1.1",
     "website_url": "https://github.com/R2Spyglass/IMC.Spyglass/",
     "description": "A server-side mod that handles sanctions based on player reports on the community Northstar Discord.",
     "dependencies": []

--- a/mod.json
+++ b/mod.json
@@ -1,7 +1,7 @@
 {
     "Name": "IMC.Spyglass",
     "Description": "A server-side mod that handles sanctions based on player reports on the community Northstar Discord.",
-    "Version": "2.2.0",
+    "Version": "2.2.1",
     "LoadPriority": 2,
     "ConVars": [
         {

--- a/mod/scripts/vscripts/spyglass/spyglass.nut
+++ b/mod/scripts/vscripts/spyglass/spyglass.nut
@@ -89,7 +89,7 @@ void function OnPrematchStarted()
     Spyglass_HasInitialized = true;
 
     printt("[Spyglass] Prematch started, connecting to API...");
-    Spyglass_SayAll(format("Initializing core, version %s.", NSGetModVersionByModName("IMC.Spyglass")));
+    Spyglass_SayAll(format("Initializing core, version %s.", Spyglass_GetCurrentVersion()));
     Spyglass_SayAll("Establishing uplink to IMC sanction database...");
 
     if (!SpyglassApi_GetStats(OnStatsRequestComplete))

--- a/mod/scripts/vscripts/spyglass/utils.nut
+++ b/mod/scripts/vscripts/spyglass/utils.nut
@@ -245,6 +245,22 @@ int function Spyglass_CompareVersions(Spyglass_Version localVersion, Spyglass_Ve
     return -1;
 }
 
+/**
+ * Gets the currently enabled local version of Spyglass.
+ * @returns the the string representation of the version.
+ */
+string function Spyglass_GetCurrentVersion()
+{
+    foreach (ModInfo versionInfo in NSGetModInformation("IMC.Spyglass"))
+    {
+        if (versionInfo.enabled)
+            return versionInfo.version
+    }
+
+    // technically not, but since this code exists in IMC.Spyglass then surely one version of it is enabled
+    unreachable
+}
+
 /** 
  * Checks the local version against the API's version if cached. 
  * Returns a Spyglass_VersionCheckResult in integer form.
@@ -255,7 +271,7 @@ int function Spyglass_VersionCheck()
     Spyglass_Version minimumVersion;
     Spyglass_Version latestVersion;
 
-    if (!Spyglass_ParseVersion(NSGetModVersionByModName("IMC.Spyglass"), localVersion)
+    if (!Spyglass_ParseVersion(Spyglass_GetCurrentVersion(), localVersion)
         || !Spyglass_ParseVersion(Spyglass_GetMinimumVersion(), minimumVersion)
         || !Spyglass_ParseVersion(Spyglass_GetLatestVersion(), latestVersion))
     {


### PR DESCRIPTION
Fixes compile error in v1.29.0 of NS.

The squirrel mod API was changed a bit, so updates are needed